### PR TITLE
Fixing cert location.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ RUN apk add --no-cache bash && \
 USER node
 # Append SAN section to openssl.cnf and generate a new self-signed certificate and key
 RUN mkdir -p /home/node/ssl/certs && \
-    cp /etc/ssl1.1/openssl.cnf /home/node/ssl/openssl.cnf && \
+    cp /etc/ssl/openssl.cnf /home/node/ssl/openssl.cnf && \
     printf "[SAN]\nsubjectAltName=DNS:*.hul.harvard.edu,DNS:*.lts.harvard.edu" >> /home/node/ssl/openssl.cnf && \
     openssl req -new -newkey rsa:4096 -days 3650 -nodes -x509 -subj "/C=US/ST=Massachusetts/L=Cambridge/O=Library Technology Services/CN=*.lib.harvard.edu" -extensions SAN -reqexts SAN -config /home/node/ssl/openssl.cnf -keyout /home/node/ssl/certs/server.key -out /home/node/ssl/certs/server.crt && \
     mkdir -p /home/node/app

--- a/DockerfileLocal
+++ b/DockerfileLocal
@@ -10,7 +10,7 @@ RUN apk add --no-cache bash && \
 USER node
 # Append SAN section to openssl.cnf and generate a new self-signed certificate and key
 RUN mkdir -p /home/node/ssl/certs && \
-    cp /etc/ssl1.1/openssl.cnf /home/node/ssl/openssl.cnf && \
+    cp /etc/ssl/openssl.cnf /home/node/ssl/openssl.cnf && \
     printf "[SAN]\nsubjectAltName=DNS:*.hul.harvard.edu,DNS:*.lts.harvard.edu" >> /home/node/ssl/openssl.cnf && \
     openssl req -new -newkey rsa:4096 -days 3650 -nodes -x509 -subj "/C=US/ST=Massachusetts/L=Cambridge/O=Library Technology Services/CN=*.lib.harvard.edu" -extensions SAN -reqexts SAN -config /home/node/ssl/openssl.cnf -keyout /home/node/ssl/certs/server.key -out /home/node/ssl/certs/server.crt && \
     mkdir -p /home/node/app


### PR DESCRIPTION
**Fixing openssl cert location.**
* * *

# What does this Pull Request do?
The location of the openssl.cnf file has moved back to `/etc/ssl/` from `/etc/ssl1.1/`. This PR updates the Dockerfiles so that the container can successfully build.
 
# How should this be tested?

A description of what steps someone could take to:
* Rebuild the container off of the `fix-openssl` branch
* Confirm the application builds successfully and is viewable in the browser.

# Test coverage
Yes/No: Are changes in this pull-request covered by:
- unit tests? No
- integration tests? No